### PR TITLE
fix: handle browser open failure on headless machines

### DIFF
--- a/.beans/mastodont-7kfb--error-due-to-headless-machine-and-no-browser.md
+++ b/.beans/mastodont-7kfb--error-due-to-headless-machine-and-no-browser.md
@@ -5,7 +5,7 @@ status: in-progress
 type: bug
 priority: high
 created_at: 2026-02-22T06:46:02Z
-updated_at: 2026-02-22T18:23:22Z
+updated_at: 2026-02-22T18:26:52Z
 ---
 
 ℹ Opening browser to instance blocklist... 22:10:36
@@ -29,3 +29,12 @@ spawnargs: [ 'https:///admin/instances?limited=1' ]
 }
 
 There is no GUI on this machine, the app does not handle that cleanly
+
+
+## Branch
+fix/mastodont-7kfb-headless-browser-error
+
+## Todo
+- [x] Write failing test for browser open error handling
+- [x] Implement graceful error handling for open() in index.ts
+- [x] Verify all tests pass

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,8 @@
       "Bash(beans update:*)",
       "Bash(git stash:*)",
       "Bash(git add:*)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
+      "Bash(git push:*)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,10 @@
       "Bash(gh pr create:*)",
       "Bash(npx vitest:*)",
       "Bash(beans show:*)",
-      "Bash(beans update:*)"
+      "Bash(beans update:*)",
+      "Bash(git stash:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
   },
   "lint-staged": {
     "src/**/*.ts": [
-      "npm tsc:check --types node --esModuleInterop --target esnext --module nodenext",
-      "npm lint:fix",
-      "npm format"
+      "pnpm run tsc:check --types node --esModuleInterop --target esnext --module nodenext",
+      "pnpm run lint:fix",
+      "pnpm run format"
     ]
   },
   "devDependencies": {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // All mocks must be declared before any dynamic imports
 vi.mock('consola', () => ({
-  consola: { log: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  consola: { log: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 vi.mock('open', () => ({ default: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('../args.js', () => ({ __esModule: true, args: vi.fn() }));
@@ -124,5 +124,14 @@ describe('index (main)', () => {
     const mocks = await setupMocks({ nonInteractive: true });
     await runMain();
     expect(mocks.mockOpen).not.toHaveBeenCalled();
+  });
+
+  it('handles browser open failure gracefully and logs the URL', async () => {
+    const mocks = await setupMocks({ endpoint: 'https://mastodon.social' });
+    mocks.mockOpen.mockRejectedValue(new Error('spawn xdg-open ENOENT'));
+    await runMain();
+    expect(mocks.mockConsola.warn).toHaveBeenCalledWith(
+      expect.stringContaining('https://mastodon.social/admin/instances?limited=1'),
+    );
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,8 +37,13 @@ const main = async (): Promise<void> => {
 
     // open browser
     if (!flags.nonInteractive) {
+      const url = `${config.endpoint}/admin/instances?limited=1`;
       consola.info('Opening browser to instance blocklist...');
-      await open(`${config.endpoint}/admin/instances?limited=1`);
+      try {
+        await open(url);
+      } catch {
+        consola.warn(`Could not open browser. Visit the blocklist manually: ${url}`);
+      }
     }
   }
 };


### PR DESCRIPTION
## Summary

- Wraps `open()` call in a try-catch so headless machines without `xdg-open` don't crash the process
- Logs the blocklist URL via `consola.warn` so users can visit it manually when the browser can't be opened
- Adds test verifying graceful error handling when `open()` rejects

## Test plan

- [x] New test: `handles browser open failure gracefully and logs the URL`
- [x] All 52 existing tests pass
- [x] TypeScript type check clean
- [ ] Manual: run on a headless Linux machine and verify warning is printed instead of crash

Closes mastodont-7kfb

Resolves issue #10