### PR TITLE
feat: mark imported domains with [import-mastodont] marker

### DIFF
--- a/.beans/mastodont-7kfb--error-due-to-headless-machine-and-no-browser.md
+++ b/.beans/mastodont-7kfb--error-due-to-headless-machine-and-no-browser.md
@@ -1,11 +1,11 @@
 ---
 # mastodont-7kfb
 title: Error due to headless machine and no browser
-status: in-progress
+status: completed
 type: bug
 priority: high
 created_at: 2026-02-22T06:46:02Z
-updated_at: 2026-02-22T18:26:52Z
+updated_at: 2026-02-22T18:32:37Z
 ---
 
 ℹ Opening browser to instance blocklist... 22:10:36
@@ -29,12 +29,3 @@ spawnargs: [ 'https:///admin/instances?limited=1' ]
 }
 
 There is no GUI on this machine, the app does not handle that cleanly
-
-
-## Branch
-fix/mastodont-7kfb-headless-browser-error
-
-## Todo
-- [x] Write failing test for browser open error handling
-- [x] Implement graceful error handling for open() in index.ts
-- [x] Verify all tests pass

--- a/.beans/mastodont-9z5a--mark-imported-instances-with-import-mastodont.md
+++ b/.beans/mastodont-9z5a--mark-imported-instances-with-import-mastodont.md
@@ -5,7 +5,7 @@ status: in-progress
 type: feature
 priority: normal
 created_at: 2026-02-22T06:45:48Z
-updated_at: 2026-02-22T18:36:25Z
+updated_at: 2026-02-22T20:22:05Z
 ---
 
 Where instances have been added to a blocklist using this tool add reason 'import-mastodont' to the blocking reason published by the server.  Then when running your script to generate the most-defederated list you could exclude those added by this tool.  Otherwise if it gets reasonable adoption you have some circularity, it's on the list because it's on the list, and lots of instances subscribe to the list.  Being on a blocklist is not a good reason for being on a blocklist..
@@ -16,6 +16,9 @@ Where instances have been added to a blocklist using this tool add reason 'impor
 feature/mastodont-9z5a-import-marker
 
 ## Todo
-- [ ] Write failing test for import marker
-- [ ] Implement marker in blocks.ts
-- [ ] Verify all tests pass
+- [x] Write failing test for import marker
+- [x] Implement marker in blocks.ts
+- [x] Verify all tests pass
+
+## PR
+https://github.com/selfagency/mastodont/pull/15

--- a/.beans/mastodont-9z5a--mark-imported-instances-with-import-mastodont.md
+++ b/.beans/mastodont-9z5a--mark-imported-instances-with-import-mastodont.md
@@ -1,11 +1,21 @@
 ---
 # mastodont-9z5a
 title: Mark imported instances with <import-mastodont>
-status: todo
+status: in-progress
 type: feature
 priority: normal
 created_at: 2026-02-22T06:45:48Z
-updated_at: 2026-02-22T06:47:26Z
+updated_at: 2026-02-22T18:36:25Z
 ---
 
 Where instances have been added to a blocklist using this tool add reason 'import-mastodont' to the blocking reason published by the server.  Then when running your script to generate the most-defederated list you could exclude those added by this tool.  Otherwise if it gets reasonable adoption you have some circularity, it's on the list because it's on the list, and lots of instances subscribe to the list.  Being on a blocklist is not a good reason for being on a blocklist..
+
+
+
+## Branch
+feature/mastodont-9z5a-import-marker
+
+## Todo
+- [ ] Write failing test for import marker
+- [ ] Implement marker in blocks.ts
+- [ ] Verify all tests pass

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,14 @@
       "Bash(beans update:*)",
       "Bash(git stash:*)",
       "Bash(git pull:*)",
-      "Bash(git stash pop:*)"
+      "Bash(git stash pop:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh api:*)",
+      "Bash(gh run list:*)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,9 +17,8 @@
       "Bash(beans show:*)",
       "Bash(beans update:*)",
       "Bash(git stash:*)",
-      "Bash(git add:*)",
-      "Bash(git commit:*)",
-      "Bash(git push:*)"
+      "Bash(git pull:*)",
+      "Bash(git stash pop:*)"
     ]
   }
 }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run tests
         env:
           CI: true
-        run: pnpm test --silent --coverage --reporter=junit --outputFile=test-report.junit.xml
+        run: pnpm test --coverage --reporter=default --reporter=junit --outputFile=test-report.junit.xml
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}

--- a/src/__tests__/blocks.test.ts
+++ b/src/__tests__/blocks.test.ts
@@ -367,7 +367,32 @@ describe('setBlocks', () => {
 
     expect(postCalls).toHaveLength(1);
     const body = new URLSearchParams(postCalls[0]![1]!.body as string);
-    expect(body.get('private_comment')).toBe('Internal note');
+    expect(body.get('private_comment')).toBe('[import-mastodont] Internal note');
     expect(body.get('public_comment')).toBe('Public reason');
+  });
+
+  it('sets private_comment to [import-mastodont] when no privateComment provided', async () => {
+    const config: MastodontConfig = {
+      ...baseConfig,
+      blocklist: '/path/to/blocklist.txt',
+    };
+
+    mockFetch
+      .mockResolvedValueOnce(createMockResponse(200, [], null) as never)
+      .mockResolvedValue(createMockResponse(200, {}) as never);
+
+    mockIsUrl.mockReturnValue(false);
+    mockReadFile.mockResolvedValueOnce('marker.example\n' as never);
+
+    await setBlocks(config);
+
+    const postCalls = mockFetch.mock.calls.filter(([, opts]) => {
+      const options = opts as { method?: string } | undefined;
+      return options?.method === 'POST';
+    });
+
+    expect(postCalls).toHaveLength(1);
+    const body = new URLSearchParams(postCalls[0]![1]!.body as string);
+    expect(body.get('private_comment')).toBe('[import-mastodont]');
   });
 });

--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -130,9 +130,8 @@ export const setBlocks = async (config: MastodontConfig) => {
         body.set('reject_reports', String(config.rejectReports || false));
       }
 
-      if (config.privateComment) {
-        body.set('private_comment', config.privateComment);
-      }
+      const marker = '[import-mastodont]';
+      body.set('private_comment', config.privateComment ? `${marker} ${config.privateComment}` : marker);
 
       if (config.publicComment) {
         body.set('public_comment', config.publicComment);


### PR DESCRIPTION
## Summary

- Always prepends `[import-mastodont]` to the `private_comment` field when creating domain blocks via the Mastodon API
- If a user provides `--privateComment "Spam source"`, the API receives `[import-mastodont] Spam source`
- If no private comment is set, the API receives `[import-mastodont]`
- This allows admins to distinguish tool-imported blocks from manual ones, preventing circular blocklist adoption (domains being on the list because they're on the list)

## Test plan

- [x] Updated existing test: `private_comment` now includes marker when user comment provided
- [x] New test: `private_comment` set to `[import-mastodont]` when no user comment provided
- [x] All 53 tests pass
- [x] TypeScript type check clean
- [ ] Manual: run import and verify `private_comment` in Mastodon admin UI shows the marker

Closes mastodont-9z5a

Addresses #9 