### PR TITLE
feat: add --allowlist flag to remove or skip blocked domains

### DIFF
--- a/.beans/mastodont-9dwy--add-support-for-users-vs-admins-only.md
+++ b/.beans/mastodont-9dwy--add-support-for-users-vs-admins-only.md
@@ -1,10 +1,10 @@
 ---
 # mastodont-9dwy
 title: Add support for users (vs. admins only)
-status: todo
+status: scrapped
 type: feature
 priority: normal
 created_at: 2026-02-22T06:44:18Z
-updated_at: 2026-02-22T06:47:13Z
+updated_at: 2026-02-22T20:36:22Z
 ---
 

--- a/.beans/mastodont-uq0a--function-to-remove-blocked-domains.md
+++ b/.beans/mastodont-uq0a--function-to-remove-blocked-domains.md
@@ -1,7 +1,7 @@
 ---
 # mastodont-uq0a
 title: Function to remove blocked domains
-status: todo
+status: completed
 type: feature
 priority: normal
 created_at: 2026-02-22T06:46:36Z
@@ -12,3 +12,24 @@ Requesting a function to remove blocked domains from the server or whitelist ser
 
 Feed a .txt/.json/.csv file in and the app removes those entries from the blocklist or prevents them from being added from other lists.
 Cheers and thanks
+
+## Todo
+
+- [x] Write failing tests for `loadDomainList` helper (txt/json/csv/url support)
+- [x] Write failing tests for `removeBlocks` (deletes matching blocks via API)
+- [x] Write failing tests for `setBlocks` allowlist filtering
+- [x] Add `allowlist` to types (`MastodontArgs`/`MastodontConfig`)
+- [x] Add `--allowlist` flag to `args.ts`
+- [x] Implement `loadDomainList`, `removeBlocks`, update `setBlocks`
+- [x] Update `index.ts` to dispatch `removeBlocks` vs `setBlocks`
+- [x] Run all tests and verify they pass
+
+## Summary of Changes
+
+- **`src/types/index.d.ts`**: Added `allowlist?: string` to `MastodontArgs`
+- **`src/args.ts`**: Added `--allowlist` / `-a` CLI flag
+- **`src/blocks.ts`**:
+  - `loadDomainList(source)`: shared helper that loads domains from a `.txt`, `.json`, or `.csv` file or URL; strips headers and empty lines
+  - `removeBlocks(config)`: fetches current blocks then DELETEs any whose domain appears in the allowlist file; uses `DELETE /api/v1/admin/domain_blocks/:id`
+  - `setBlocks`: refactored to use `loadDomainList`; when `config.allowlist` is set, domains in the allowlist are excluded from being added
+- **`src/index.ts`**: dispatches to `removeBlocks` when `--allowlist` is given without `--blocklist`; otherwise calls `setBlocks` (which applies the allowlist filter internally)

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -27,7 +27,8 @@
       "Bash(gh api:*)",
       "Bash(gh run list:*)",
       "Skill(commit-commands:commit-push-pr)",
-      "Skill(commit-commands:commit-push-pr:*)"
+      "Skill(commit-commands:commit-push-pr:*)",
+      "Bash(pnpm run lint:*)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -25,7 +25,9 @@
       "Bash(gh pr checks:*)",
       "Bash(gh run view:*)",
       "Bash(gh api:*)",
-      "Bash(gh run list:*)"
+      "Bash(gh run list:*)",
+      "Skill(commit-commands:commit-push-pr)",
+      "Skill(commit-commands:commit-push-pr:*)"
     ]
   }
 }

--- a/src/__tests__/blocks.test.ts
+++ b/src/__tests__/blocks.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
 
 vi.mock('node-fetch', () => ({ default: vi.fn() }));
 vi.mock('fs/promises', () => ({ readFile: vi.fn() }));
@@ -20,14 +21,29 @@ vi.mock('consola', () => ({
 }));
 
 import fetch from 'node-fetch';
+import ora from 'ora';
+import { consola } from 'consola';
 import { readFile } from 'fs/promises';
 import isUrl from 'is-url-superb';
 import { getBlocks, setBlocks, loadDomainList, removeBlocks } from '../blocks.js';
 import type { Block, MastodontConfig } from '../types/index.js';
 
+type MockSpinner = {
+  start: Mock;
+  succeed: Mock;
+  fail: Mock;
+  warn: Mock;
+  stopAndPersist: Mock;
+  text: string;
+};
+
 const mockFetch = vi.mocked(fetch);
 const mockReadFile = vi.mocked(readFile);
 const mockIsUrl = vi.mocked(isUrl);
+const mockConsola = vi.mocked(consola);
+const spinner = vi.mocked(ora)('') as unknown as MockSpinner;
+
+let exitSpy: Mock;
 
 const createMockResponse = (status: number, body: unknown, linkHeader: string | null = null) => ({
   status,
@@ -51,11 +67,14 @@ const baseConfig: MastodontConfig = {
   accessToken: 'test-token',
 };
 
+const callsByMethod = (method: string) =>
+  mockFetch.mock.calls.filter(([, opts]) => (opts as { method?: string } | undefined)?.method === method);
+
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.spyOn(process, 'exit').mockImplementation((() => {
+  exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
     throw new Error('process.exit');
-  }) as never);
+  }) as never) as unknown as Mock;
 });
 
 describe('getBlocks', () => {
@@ -78,7 +97,6 @@ describe('getBlocks', () => {
   it('handles pagination via Link header across two pages', async () => {
     const page1 = [createBlock('page1.example')];
     const page2 = [createBlock('page2.example')];
-
     const linkHeader = '<https://mastodon.example/api/v1/admin/domain_blocks?page=2>; rel="next"';
 
     mockFetch
@@ -108,11 +126,10 @@ describe('getBlocks', () => {
     const blocks = [createBlock('quiet.example')];
     mockFetch.mockResolvedValueOnce(createMockResponse(200, blocks) as never);
 
-    const ora = (await import('ora')).default;
     const result = await getBlocks(baseConfig, true);
 
     expect(result).toEqual(blocks);
-    expect(ora).not.toHaveBeenCalled();
+    expect(vi.mocked(ora)).not.toHaveBeenCalled();
   });
 
   it('sends the correct Authorization header', async () => {
@@ -147,11 +164,7 @@ describe('setBlocks', () => {
 
     await setBlocks(config);
 
-    const postCalls = mockFetch.mock.calls.filter(([, opts]) => {
-      const options = opts as { method?: string } | undefined;
-      return options?.method === 'POST';
-    });
-
+    const postCalls = callsByMethod('POST');
     expect(postCalls).toHaveLength(2);
     expect(postCalls[0]![0]).toBe('https://mastodon.example/api/v1/admin/domain_blocks');
     expect(postCalls[1]![0]).toBe('https://mastodon.example/api/v1/admin/domain_blocks');
@@ -159,10 +172,9 @@ describe('setBlocks', () => {
 
   it('skips domains already present in current blocks', async () => {
     const config: MastodontConfig = { ...baseConfig, blocklist: '/path/to/blocklist.txt' };
-    const existingBlock = createBlock('existing.example');
 
     mockFetch
-      .mockResolvedValueOnce(createMockResponse(200, [existingBlock], null) as never)
+      .mockResolvedValueOnce(createMockResponse(200, [createBlock('existing.example')], null) as never)
       .mockResolvedValue(createMockResponse(200, {}) as never);
 
     mockIsUrl.mockReturnValue(false);
@@ -170,11 +182,7 @@ describe('setBlocks', () => {
 
     await setBlocks(config);
 
-    const postCalls = mockFetch.mock.calls.filter(([, opts]) => {
-      const options = opts as { method?: string } | undefined;
-      return options?.method === 'POST';
-    });
-
+    const postCalls = callsByMethod('POST');
     expect(postCalls).toHaveLength(1);
     const body = new URLSearchParams(postCalls[0]![1]!.body as string);
     expect(body.get('domain')).toBe('new.example');
@@ -182,20 +190,13 @@ describe('setBlocks', () => {
 
   it('calls process.exit(0) when all blocklist domains are already blocked', async () => {
     const config: MastodontConfig = { ...baseConfig, blocklist: '/path/to/blocklist.txt' };
-    const existingBlock = createBlock('existing.example');
 
-    mockFetch.mockResolvedValueOnce(createMockResponse(200, [existingBlock], null) as never);
-
+    mockFetch.mockResolvedValueOnce(createMockResponse(200, [createBlock('existing.example')], null) as never);
     mockIsUrl.mockReturnValue(false);
     mockReadFile.mockResolvedValueOnce('existing.example\n' as never);
 
-    try {
-      await setBlocks(config);
-    } catch (err) {
-      expect((err as Error).message).toBe('process.exit');
-    }
-
-    expect(process.exit).toHaveBeenCalledWith(0);
+    await expect(setBlocks(config)).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
   it('reads blocklist from a local file when isUrl returns false', async () => {
@@ -233,17 +234,10 @@ describe('setBlocks', () => {
   });
 
   it('calls process.exit(1) when no blocklist is specified in config', async () => {
-    const config: MastodontConfig = { ...baseConfig };
-
     mockFetch.mockResolvedValueOnce(createMockResponse(200, [], null) as never);
 
-    try {
-      await setBlocks(config);
-    } catch (err) {
-      expect((err as Error).message).toBe('process.exit');
-    }
-
-    expect(process.exit).toHaveBeenCalledWith(1);
+    await expect(setBlocks(baseConfig)).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
   it('handles 422 responses silently without counting as failures', async () => {
@@ -256,14 +250,9 @@ describe('setBlocks', () => {
     mockIsUrl.mockReturnValue(false);
     mockReadFile.mockResolvedValueOnce('already.example\n' as never);
 
-    const { consola } = await import('consola');
-
     await setBlocks(config);
 
-    expect(consola.debug).toHaveBeenCalledWith(expect.stringContaining('422'));
-
-    const ora = (await import('ora')).default;
-    const spinner = ora('');
+    expect(mockConsola.debug).toHaveBeenCalledWith(expect.stringContaining('422'));
     expect(spinner.warn).not.toHaveBeenCalled();
     expect(spinner.succeed).toHaveBeenCalledWith(expect.stringContaining('0 domains'));
   });
@@ -280,8 +269,6 @@ describe('setBlocks', () => {
 
     await setBlocks(config);
 
-    const ora = (await import('ora')).default;
-    const spinner = ora('');
     expect(spinner.warn).toHaveBeenCalledWith(expect.stringContaining('0 succeeded, 1 failed'));
   });
 
@@ -303,11 +290,7 @@ describe('setBlocks', () => {
 
     await setBlocks(config);
 
-    const postCalls = mockFetch.mock.calls.filter(([, opts]) => {
-      const options = opts as { method?: string } | undefined;
-      return options?.method === 'POST';
-    });
-
+    const postCalls = callsByMethod('POST');
     expect(postCalls).toHaveLength(1);
     const body = new URLSearchParams(postCalls[0]![1]!.body as string);
     expect(body.get('reject_media')).toBe('true');
@@ -332,11 +315,7 @@ describe('setBlocks', () => {
 
     await setBlocks(config);
 
-    const postCalls = mockFetch.mock.calls.filter(([, opts]) => {
-      const options = opts as { method?: string } | undefined;
-      return options?.method === 'POST';
-    });
-
+    const postCalls = callsByMethod('POST');
     expect(postCalls).toHaveLength(1);
     const body = new URLSearchParams(postCalls[0]![1]!.body as string);
     expect(body.get('reject_media')).toBeNull();
@@ -360,11 +339,7 @@ describe('setBlocks', () => {
 
     await setBlocks(config);
 
-    const postCalls = mockFetch.mock.calls.filter(([, opts]) => {
-      const options = opts as { method?: string } | undefined;
-      return options?.method === 'POST';
-    });
-
+    const postCalls = callsByMethod('POST');
     expect(postCalls).toHaveLength(1);
     const body = new URLSearchParams(postCalls[0]![1]!.body as string);
     expect(body.get('private_comment')).toBe('[import-mastodont] Internal note');
@@ -386,11 +361,7 @@ describe('setBlocks', () => {
 
     await setBlocks(config);
 
-    const postCalls = mockFetch.mock.calls.filter(([, opts]) => {
-      const options = opts as { method?: string } | undefined;
-      return options?.method === 'POST';
-    });
-
+    const postCalls = callsByMethod('POST');
     expect(postCalls).toHaveLength(1);
     const body = new URLSearchParams(postCalls[0]![1]!.body as string);
     expect(body.get('private_comment')).toBe('[import-mastodont]');
@@ -408,18 +379,13 @@ describe('setBlocks', () => {
       .mockResolvedValue(createMockResponse(200, {}) as never);
 
     mockIsUrl.mockReturnValue(false);
-    // blocklist file read first, then allowlist file
     mockReadFile
       .mockResolvedValueOnce('blocked.example\nallowed.example\n' as never)
       .mockResolvedValueOnce('allowed.example\n' as never);
 
     await setBlocks(config);
 
-    const postCalls = mockFetch.mock.calls.filter(([, opts]) => {
-      const options = opts as { method?: string } | undefined;
-      return options?.method === 'POST';
-    });
-
+    const postCalls = callsByMethod('POST');
     expect(postCalls).toHaveLength(1);
     const body = new URLSearchParams(postCalls[0]![1]!.body as string);
     expect(body.get('domain')).toBe('blocked.example');
@@ -485,25 +451,14 @@ describe('loadDomainList', () => {
 
 describe('removeBlocks', () => {
   it('calls process.exit(1) when no allowlist is specified', async () => {
-    const config: MastodontConfig = { ...baseConfig };
-
     mockFetch.mockResolvedValueOnce(createMockResponse(200, [], null) as never);
 
-    try {
-      await removeBlocks(config);
-    } catch (err) {
-      expect((err as Error).message).toBe('process.exit');
-    }
-
-    expect(process.exit).toHaveBeenCalledWith(1);
+    await expect(removeBlocks(baseConfig)).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
   it('sends DELETE requests for domains that match existing blocks', async () => {
-    const config: MastodontConfig = {
-      ...baseConfig,
-      allowlist: '/path/to/removals.txt',
-    };
-
+    const config: MastodontConfig = { ...baseConfig, allowlist: '/path/to/removals.txt' };
     const existingBlocks = [
       { ...createBlock('remove.example'), id: '42' },
       { ...createBlock('keep.example'), id: '99' },
@@ -518,41 +473,25 @@ describe('removeBlocks', () => {
 
     await removeBlocks(config);
 
-    const deleteCalls = mockFetch.mock.calls.filter(([, opts]) => {
-      const options = opts as { method?: string } | undefined;
-      return options?.method === 'DELETE';
-    });
-
+    const deleteCalls = callsByMethod('DELETE');
     expect(deleteCalls).toHaveLength(1);
     expect(deleteCalls[0]![0]).toBe('https://mastodon.example/api/v1/admin/domain_blocks/42');
   });
 
   it('sends no DELETE requests when no allowlist domains match current blocks', async () => {
-    const config: MastodontConfig = {
-      ...baseConfig,
-      allowlist: '/path/to/removals.txt',
-    };
+    const config: MastodontConfig = { ...baseConfig, allowlist: '/path/to/removals.txt' };
 
     mockFetch.mockResolvedValueOnce(createMockResponse(200, [createBlock('unrelated.example')], null) as never);
-
     mockIsUrl.mockReturnValue(false);
     mockReadFile.mockResolvedValueOnce('notblocked.example\n' as never);
 
     await removeBlocks(config);
 
-    const deleteCalls = mockFetch.mock.calls.filter(([, opts]) => {
-      const options = opts as { method?: string } | undefined;
-      return options?.method === 'DELETE';
-    });
-
-    expect(deleteCalls).toHaveLength(0);
+    expect(callsByMethod('DELETE')).toHaveLength(0);
   });
 
   it('reports the count of successfully removed blocks', async () => {
-    const config: MastodontConfig = {
-      ...baseConfig,
-      allowlist: '/path/to/removals.txt',
-    };
+    const config: MastodontConfig = { ...baseConfig, allowlist: '/path/to/removals.txt' };
 
     mockFetch
       .mockResolvedValueOnce(createMockResponse(200, [{ ...createBlock('a.example'), id: '1' }], null) as never)
@@ -561,19 +500,13 @@ describe('removeBlocks', () => {
     mockIsUrl.mockReturnValue(false);
     mockReadFile.mockResolvedValueOnce('a.example\n' as never);
 
-    const ora = (await import('ora')).default;
-
     await removeBlocks(config);
 
-    const spinner = ora('');
     expect(spinner.succeed).toHaveBeenCalledWith(expect.stringContaining('1'));
   });
 
   it('reports failures when DELETE requests return non-success status', async () => {
-    const config: MastodontConfig = {
-      ...baseConfig,
-      allowlist: '/path/to/removals.txt',
-    };
+    const config: MastodontConfig = { ...baseConfig, allowlist: '/path/to/removals.txt' };
 
     mockFetch
       .mockResolvedValueOnce(createMockResponse(200, [{ ...createBlock('bad.example'), id: '77' }], null) as never)
@@ -584,8 +517,6 @@ describe('removeBlocks', () => {
 
     await removeBlocks(config);
 
-    const ora = (await import('ora')).default;
-    const spinner = ora('');
     expect(spinner.warn).toHaveBeenCalledWith(expect.stringContaining('failed'));
   });
 });

--- a/src/__tests__/blocks.test.ts
+++ b/src/__tests__/blocks.test.ts
@@ -22,7 +22,7 @@ vi.mock('consola', () => ({
 import fetch from 'node-fetch';
 import { readFile } from 'fs/promises';
 import isUrl from 'is-url-superb';
-import { getBlocks, setBlocks } from '../blocks.js';
+import { getBlocks, setBlocks, loadDomainList, removeBlocks } from '../blocks.js';
 import type { Block, MastodontConfig } from '../types/index.js';
 
 const mockFetch = vi.mocked(fetch);
@@ -394,5 +394,198 @@ describe('setBlocks', () => {
     expect(postCalls).toHaveLength(1);
     const body = new URLSearchParams(postCalls[0]![1]!.body as string);
     expect(body.get('private_comment')).toBe('[import-mastodont]');
+  });
+
+  it('skips domains present in the allowlist when adding blocks', async () => {
+    const config: MastodontConfig = {
+      ...baseConfig,
+      blocklist: '/path/to/blocklist.txt',
+      allowlist: '/path/to/allowlist.txt',
+    };
+
+    mockFetch
+      .mockResolvedValueOnce(createMockResponse(200, [], null) as never)
+      .mockResolvedValue(createMockResponse(200, {}) as never);
+
+    mockIsUrl.mockReturnValue(false);
+    // blocklist file read first, then allowlist file
+    mockReadFile
+      .mockResolvedValueOnce('blocked.example\nallowed.example\n' as never)
+      .mockResolvedValueOnce('allowed.example\n' as never);
+
+    await setBlocks(config);
+
+    const postCalls = mockFetch.mock.calls.filter(([, opts]) => {
+      const options = opts as { method?: string } | undefined;
+      return options?.method === 'POST';
+    });
+
+    expect(postCalls).toHaveLength(1);
+    const body = new URLSearchParams(postCalls[0]![1]!.body as string);
+    expect(body.get('domain')).toBe('blocked.example');
+  });
+});
+
+describe('loadDomainList', () => {
+  it('loads domains from a newline-separated .txt file', async () => {
+    mockIsUrl.mockReturnValue(false);
+    mockReadFile.mockResolvedValueOnce('evil.example\nspam.example\n' as never);
+
+    const domains = await loadDomainList('/path/to/list.txt');
+
+    expect(domains).toEqual(['evil.example', 'spam.example']);
+  });
+
+  it('loads domains from a JSON array file', async () => {
+    mockIsUrl.mockReturnValue(false);
+    mockReadFile.mockResolvedValueOnce('["json.example", "another.example"]' as never);
+
+    const domains = await loadDomainList('/path/to/list.json');
+
+    expect(domains).toEqual(['json.example', 'another.example']);
+  });
+
+  it('loads first-column domains from a CSV file', async () => {
+    mockIsUrl.mockReturnValue(false);
+    mockReadFile.mockResolvedValueOnce('domain,reason\ncsv.example,spam\nother.example,abuse\n' as never);
+
+    const domains = await loadDomainList('/path/to/list.csv');
+
+    expect(domains).toEqual(['csv.example', 'other.example']);
+  });
+
+  it('strips a CSV header row when first cell is "domain"', async () => {
+    mockIsUrl.mockReturnValue(false);
+    mockReadFile.mockResolvedValueOnce('domain,notes\ncsv.example,spam\n' as never);
+
+    const domains = await loadDomainList('/path/to/list.csv');
+
+    expect(domains).not.toContain('domain');
+    expect(domains).toEqual(['csv.example']);
+  });
+
+  it('fetches a remote URL and parses the result as a txt list', async () => {
+    mockIsUrl.mockReturnValue(true);
+    mockFetch.mockResolvedValueOnce(createMockResponse(200, 'remote.example\nother.example\n') as never);
+
+    const domains = await loadDomainList('https://lists.example/domains.txt');
+
+    expect(domains).toEqual(['remote.example', 'other.example']);
+  });
+
+  it('filters out empty lines and whitespace-only entries', async () => {
+    mockIsUrl.mockReturnValue(false);
+    mockReadFile.mockResolvedValueOnce('good.example\n\n   \nbad.example\n' as never);
+
+    const domains = await loadDomainList('/path/to/list.txt');
+
+    expect(domains).toEqual(['good.example', 'bad.example']);
+  });
+});
+
+describe('removeBlocks', () => {
+  it('calls process.exit(1) when no allowlist is specified', async () => {
+    const config: MastodontConfig = { ...baseConfig };
+
+    mockFetch.mockResolvedValueOnce(createMockResponse(200, [], null) as never);
+
+    try {
+      await removeBlocks(config);
+    } catch (err) {
+      expect((err as Error).message).toBe('process.exit');
+    }
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('sends DELETE requests for domains that match existing blocks', async () => {
+    const config: MastodontConfig = {
+      ...baseConfig,
+      allowlist: '/path/to/removals.txt',
+    };
+
+    const existingBlocks = [
+      { ...createBlock('remove.example'), id: '42' },
+      { ...createBlock('keep.example'), id: '99' },
+    ];
+
+    mockFetch
+      .mockResolvedValueOnce(createMockResponse(200, existingBlocks, null) as never)
+      .mockResolvedValue(createMockResponse(200, {}) as never);
+
+    mockIsUrl.mockReturnValue(false);
+    mockReadFile.mockResolvedValueOnce('remove.example\n' as never);
+
+    await removeBlocks(config);
+
+    const deleteCalls = mockFetch.mock.calls.filter(([, opts]) => {
+      const options = opts as { method?: string } | undefined;
+      return options?.method === 'DELETE';
+    });
+
+    expect(deleteCalls).toHaveLength(1);
+    expect(deleteCalls[0]![0]).toBe('https://mastodon.example/api/v1/admin/domain_blocks/42');
+  });
+
+  it('sends no DELETE requests when no allowlist domains match current blocks', async () => {
+    const config: MastodontConfig = {
+      ...baseConfig,
+      allowlist: '/path/to/removals.txt',
+    };
+
+    mockFetch.mockResolvedValueOnce(createMockResponse(200, [createBlock('unrelated.example')], null) as never);
+
+    mockIsUrl.mockReturnValue(false);
+    mockReadFile.mockResolvedValueOnce('notblocked.example\n' as never);
+
+    await removeBlocks(config);
+
+    const deleteCalls = mockFetch.mock.calls.filter(([, opts]) => {
+      const options = opts as { method?: string } | undefined;
+      return options?.method === 'DELETE';
+    });
+
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  it('reports the count of successfully removed blocks', async () => {
+    const config: MastodontConfig = {
+      ...baseConfig,
+      allowlist: '/path/to/removals.txt',
+    };
+
+    mockFetch
+      .mockResolvedValueOnce(createMockResponse(200, [{ ...createBlock('a.example'), id: '1' }], null) as never)
+      .mockResolvedValue(createMockResponse(200, {}) as never);
+
+    mockIsUrl.mockReturnValue(false);
+    mockReadFile.mockResolvedValueOnce('a.example\n' as never);
+
+    const ora = (await import('ora')).default;
+
+    await removeBlocks(config);
+
+    const spinner = ora('');
+    expect(spinner.succeed).toHaveBeenCalledWith(expect.stringContaining('1'));
+  });
+
+  it('reports failures when DELETE requests return non-success status', async () => {
+    const config: MastodontConfig = {
+      ...baseConfig,
+      allowlist: '/path/to/removals.txt',
+    };
+
+    mockFetch
+      .mockResolvedValueOnce(createMockResponse(200, [{ ...createBlock('bad.example'), id: '77' }], null) as never)
+      .mockResolvedValue(createMockResponse(500, { error: 'server error' }) as never);
+
+    mockIsUrl.mockReturnValue(false);
+    mockReadFile.mockResolvedValueOnce('bad.example\n' as never);
+
+    await removeBlocks(config);
+
+    const ora = (await import('ora')).default;
+    const spinner = ora('');
+    expect(spinner.warn).toHaveBeenCalledWith(expect.stringContaining('failed'));
   });
 });

--- a/src/__tests__/validations.test.ts
+++ b/src/__tests__/validations.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('node-fetch', () => ({ default: vi.fn() }));
 vi.mock('is-url-superb', () => ({ default: vi.fn() }));
@@ -10,25 +10,21 @@ vi.mock('ora', () => {
 vi.mock('consola', () => ({
   consola: { debug: vi.fn(), error: vi.fn(), log: vi.fn(), info: vi.fn() },
 }));
-vi.mock('../blocks.js', () => ({ __esModule: true, getBlocks: vi.fn() }));
+vi.mock('../blocks.js', () => ({
+  getBlocks: vi.fn(),
+  setBlocks: vi.fn(),
+  loadDomainList: vi.fn(),
+  removeBlocks: vi.fn(),
+}));
 
 import isUrl from 'is-url-superb';
 import fetch from 'node-fetch';
-
-let validateEndpoint: any;
-let validateCredentials: any;
-let mockGetBlocks: any;
+import { getBlocks } from '../blocks.js';
+import { validateCredentials, validateEndpoint } from '../validations.js';
 
 const mockFetch = vi.mocked(fetch);
 const mockIsUrl = vi.mocked(isUrl);
-
-beforeAll(async () => {
-  const mods = await Promise.all([import('../blocks.js'), import('../validations.js')]);
-  // set validateEndpoint for the validateEndpoint tests
-  validateEndpoint = mods[1].validateEndpoint;
-  // prepare getBlocks mock reference
-  mockGetBlocks = vi.mocked(mods[0].getBlocks);
-});
+const mockGetBlocks = vi.mocked(getBlocks);
 
 const createMockResponse = (status: number, body: unknown) => ({
   status,
@@ -37,12 +33,12 @@ const createMockResponse = (status: number, body: unknown) => ({
 
 const baseConfig = { endpoint: 'https://mastodon.social', accessToken: 'test-token' };
 
-describe('validateEndpoint', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockIsUrl.mockReturnValue(true);
-  });
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsUrl.mockReturnValue(true);
+});
 
+describe('validateEndpoint', () => {
   it('succeeds with a valid v4+ endpoint', async () => {
     const instance = { version: '4.1.0', domain: 'mastodon.social' };
     mockFetch.mockResolvedValue(createMockResponse(200, instance) as never);
@@ -93,16 +89,6 @@ describe('validateEndpoint', () => {
 });
 
 describe('validateCredentials', () => {
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    mockIsUrl.mockReturnValue(true);
-    // import the mocked getBlocks and validations dynamically to ensure vitest mock factories are applied
-    const mods = await Promise.all([import('../blocks.js'), import('../validations.js')]);
-    mockGetBlocks = vi.mocked(mods[0].getBlocks);
-    validateEndpoint = mods[1].validateEndpoint;
-    validateCredentials = mods[1].validateCredentials;
-  });
-
   it('succeeds when getBlocks resolves', async () => {
     mockGetBlocks.mockResolvedValue([] as never);
 

--- a/src/args.ts
+++ b/src/args.ts
@@ -8,6 +8,11 @@ const specs: Args<MastodontArgs> = {
     hint: 'TOKEN',
     desc: 'Mastodon Access Token',
   }),
+  allowlist: string({
+    alias: 'a',
+    hint: 'LOCATION',
+    desc: 'Allowlist filepath or URL — removes matching blocks or skips them during import',
+  }),
   blocklist: string({
     alias: 'b',
     hint: 'LOCATION',

--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -7,6 +7,36 @@ import { type Block, type MastodontConfig } from './types/index.js';
 
 const BATCH_SIZE = 10;
 
+export const loadDomainList = async (source: string): Promise<string[]> => {
+  let raw: string;
+
+  if (isUrl(source)) {
+    raw = await (await fetch(source)).text();
+  } else {
+    raw = await readFile(source, 'utf8');
+  }
+
+  const ext = source.split('?')[0]!.toLowerCase();
+
+  if (ext.endsWith('.json')) {
+    const parsed = JSON.parse(raw) as string[];
+    return parsed.map(d => d.trim()).filter(d => d.length > 0);
+  }
+
+  if (ext.endsWith('.csv')) {
+    return raw
+      .split(/\r?\n/)
+      .map(line => line.split(',')[0]!.trim())
+      .filter((d, i) => d.length > 0 && !(i === 0 && d.toLowerCase() === 'domain'));
+  }
+
+  // Default: plain text, one domain per line
+  return raw
+    .split(/\r?\n/)
+    .map(d => d.trim())
+    .filter(d => d.length > 0);
+};
+
 const apiEndpoint = (config: MastodontConfig) => `${config.endpoint}/api/v1/admin/domain_blocks`;
 
 const authHeaders = (config: MastodontConfig) => ({
@@ -89,22 +119,27 @@ export const setBlocks = async (config: MastodontConfig) => {
       throw new Error('No blocklist specified.');
     }
 
-    if (isUrl(config.blocklist)) {
-      blocklist = (await (await fetch(config.blocklist)).text()).split(/\r?\n/);
-    } else {
-      blocklist = (await readFile(config.blocklist, 'utf8')).split('\n');
-    }
+    blocklist = await loadDomainList(config.blocklist);
   } catch (e) {
     spinner.fail();
     consola.error(`Failed to load blocklist: ${(e as Error).message}`);
     process.exit(1);
   }
 
-  // Filter out empty lines and whitespace-only entries
-  blocklist = blocklist.map(d => d.trim()).filter(d => d.length > 0);
+  let allowedDomains = new Set<string>();
+  if (config.allowlist) {
+    try {
+      const allowlist = await loadDomainList(config.allowlist);
+      allowedDomains = new Set(allowlist);
+    } catch (e) {
+      spinner.fail();
+      consola.error(`Failed to load allowlist: ${(e as Error).message}`);
+      process.exit(1);
+    }
+  }
 
   const currentDomains = new Set(currentBlocks.map(block => block.domain));
-  const blocksToAdd = blocklist.filter(domain => !currentDomains.has(domain));
+  const blocksToAdd = blocklist.filter(domain => !currentDomains.has(domain) && !allowedDomains.has(domain));
 
   if (blocksToAdd.length === 0) {
     spinner.succeed('No new domains to block.');
@@ -173,5 +208,70 @@ export const setBlocks = async (config: MastodontConfig) => {
     spinner.warn(`Completed with errors: ${succeeded} succeeded, ${failed} failed.`);
   } else {
     spinner.succeed(`Successfully blocked ${succeeded} domains.`);
+  }
+};
+
+export const removeBlocks = async (config: MastodontConfig) => {
+  const currentBlocks = await getBlocks(config, false);
+  const spinner = ora('Removing domain blocks.').start();
+
+  let domainsToRemove: string[] = [];
+  try {
+    if (!config?.allowlist) {
+      throw new Error('No allowlist specified.');
+    }
+
+    domainsToRemove = await loadDomainList(config.allowlist);
+  } catch (e) {
+    spinner.fail();
+    consola.error(`Failed to load allowlist: ${(e as Error).message}`);
+    process.exit(1);
+  }
+
+  const domainSet = new Set(domainsToRemove);
+  const blocksToRemove = currentBlocks.filter(block => domainSet.has(block.domain));
+
+  if (blocksToRemove.length === 0) {
+    spinner.succeed('No matching domain blocks to remove.');
+    return;
+  }
+
+  const url = apiEndpoint(config);
+  let succeeded = 0;
+  let failed = 0;
+
+  for (let i = 0; i < blocksToRemove.length; i += BATCH_SIZE) {
+    const batch = blocksToRemove.slice(i, i + BATCH_SIZE);
+
+    const batchPromises = batch.map(block =>
+      fetch(`${url}/${block.id}`, {
+        method: 'DELETE',
+        headers: authHeaders(config),
+      }),
+    );
+
+    try {
+      const results = await Promise.all(batchPromises);
+      for (const res of results) {
+        if (res.status >= 200 && res.status < 300) {
+          succeeded++;
+        } else {
+          failed++;
+          consola.debug(`Failed to remove block: HTTP ${res.status}`);
+        }
+      }
+    } catch (e) {
+      spinner.fail();
+      consola.error(`Error removing blocks: ${(e as Error).message}`);
+      process.exit(1);
+    }
+
+    spinner.text = `Removing domain blocks. (${Math.min(i + BATCH_SIZE, blocksToRemove.length)}/${blocksToRemove.length})`;
+  }
+
+  if (failed > 0) {
+    spinner.warn(`Completed with errors: ${succeeded} succeeded, ${failed} failed.`);
+  } else {
+    spinner.succeed(`Successfully removed ${succeeded} domain blocks.`);
   }
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -130,7 +130,7 @@ export const getConfig = async (flags: MastodontArgs): Promise<MastodontConfig> 
     try {
       config = yaml(await readFile(flags.config, 'utf-8'));
       spinner.succeed();
-    } catch (_e) {
+    } catch {
       spinner.fail();
       consola.error(`Config file not found at \`${flags.config}\`.`);
       process.exit(1);
@@ -139,7 +139,7 @@ export const getConfig = async (flags: MastodontArgs): Promise<MastodontConfig> 
     try {
       config = yaml(await readFile(defaultConfigPath, 'utf-8'));
       spinner.succeed();
-    } catch (_e) {
+    } catch {
       spinner.stopAndPersist({ text: `Default config file not found.` });
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { consola } from 'consola';
 import open from 'open';
 import { args } from './args.js';
-import { setBlocks } from './blocks.js';
+import { setBlocks, removeBlocks } from './blocks.js';
 import { getConfig, resetConfig, setConfig } from './config.js';
 import { header } from './header.js';
 import { validateCredentials, validateEndpoint } from './validations.js';
@@ -32,8 +32,12 @@ const main = async (): Promise<void> => {
       await setConfig(config);
     }
 
-    // process blocklist
-    await setBlocks(config);
+    // process blocklist or remove blocks
+    if (config.allowlist && !config.blocklist) {
+      await removeBlocks(config);
+    } else {
+      await setBlocks(config);
+    }
 
     // open browser
     if (!flags.nonInteractive) {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -5,6 +5,7 @@ export interface MastodontArgs {
   publicComment?: string;
   rejectMedia?: boolean;
   rejectReports?: boolean;
+  allowlist?: string;
   blocklist?: string;
   config?: string;
   endpoint?: string;

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -37,7 +37,7 @@ export const validateCredentials = async (config: MastodontConfig) => {
   try {
     await getBlocks(config, true);
     spinner.succeed();
-  } catch (_e) {
+  } catch {
     spinner.fail();
     throw new Error('Failed to authenticate to API. Access token is likely invalid.');
   }


### PR DESCRIPTION
## Summary

- Adds `--allowlist` / `-a` flag accepting a `.txt`, `.json`, or `.csv` file (or URL)
- **Used alone**: removes existing server blocks for listed domains via `DELETE /api/v1/admin/domain_blocks/:id`
- **Combined with `--blocklist`**: skips allowlisted domains during import so they are never added

## Changes

- `src/types/index.d.ts` — added `allowlist?: string` to `MastodontArgs`
- `src/args.ts` — added `--allowlist` / `-a` CLI flag
- `src/blocks.ts`
  - `loadDomainList(source)`: shared helper that parses `.txt`, `.json`, and `.csv` sources (file or URL), stripping empty lines and CSV `domain` headers
  - `removeBlocks(config)`: fetches current blocks then batch-DELETEs matches using the admin API
  - `setBlocks`: refactored to use `loadDomainList`; filters out allowlisted domains before adding
- `src/index.ts` — dispatches to `removeBlocks` when `--allowlist` is given without `--blocklist`

## Test plan

- [x] 12 new unit tests added for `loadDomainList`, `removeBlocks`, and allowlist filtering in `setBlocks`
- [x] All 65 tests pass (`npx vitest run`)
- [ ] Manual: `mastodont --allowlist removals.txt` removes matching blocks from live instance
- [ ] Manual: `mastodont --blocklist list.txt --allowlist exceptions.txt` skips excepted domains

Closes mastodont-uq0a

Addresses #11 